### PR TITLE
Instantiate Contarct in Realtime Bars

### DIFF
--- a/src/ib_re_actor/gateway.clj
+++ b/src/ib_re_actor/gateway.clj
@@ -423,6 +423,11 @@
                    (translate :to-ib :what-to-show what-to-show)
                    use-regular-trading-hours?))
 
+(defn cancel-real-time-bars
+  "Call this function to stop receiving real time bars for the passed in request-id"
+  [id]
+  (send-connection .cancelRealTimeBars id))
+
 (defn request-news-bulletins
   "Call this function to start receiving news bulletins. Each bulletin will
    be sent in a :news-bulletin, :exchange-unavailable, or :exchange-available

--- a/src/ib_re_actor/gateway.clj
+++ b/src/ib_re_actor/gateway.clj
@@ -416,7 +416,10 @@
 (defn request-real-time-bars
   "Start receiving real time bar results."
   [id contract what-to-show use-regular-trading-hours?]
-  (send-connection .reqRealTimeBars id contract 5
+  (send-connection .reqRealTimeBars
+                   id
+                   (map-> com.ib.client.Contract contract)
+                   5
                    (translate :to-ib :what-to-show what-to-show)
                    use-regular-trading-hours?))
 


### PR DESCRIPTION
I've modified request-real-time-bars so that the type passed in for contract matches that in the other request-\* functions.  Also added a method to cancel receiving real-time bars.
