### PR TITLE
Handle unknown codes better

### DIFF
--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -39,25 +39,37 @@ to check if if a given value is valid (known)."
          (contains? to-table# val#))
 
        (defmethod translate [:to-ib ~table-name] [_# _# val#]
-         (when val#
-           (if (valid? :to-ib ~table-name val#)
-             (to-table# val#)
-             (throw (ex-info (str "Can't translate to IB " ~table-name " " val#)
-                             {:value val#
-                              :table ~table-name
-                              :valid-values (keys to-table#)})))))
+	 (when val#
+	   (cond
+	    (valid? :to-ib ~table-name val#)
+	    (to-table# val#)
+
+	    (string? val#)
+	    val#
+
+	    :otherwise
+	    (throw (ex-info (str "Can't translate to IB " ~table-name " " val#)
+			    {:value val#
+			     :table ~table-name
+			     :valid-values (keys to-table#)})))))
 
        (defmethod valid? [:from-ib ~table-name] [_# _# val#]
          (contains? from-table# val#))
 
        (defmethod translate [:from-ib ~(keyword name)] [_# _# val#]
-         (when val#
-           (if (valid? :from-ib ~table-name val#)
-             (from-table# val#)
-             (throw (ex-info (str "Can't translate from IB " ~table-name " " val#)
-                             {:value val#
-                              :table ~table-name
-                              :valid-values (vals to-table#)}))))))))
+	 (when val#
+	   (cond
+	    (valid? :from-ib ~table-name val#)
+	    (from-table# val#)
+
+	    (string? val#)
+	    val#
+
+	    :otherwise
+	    (throw (ex-info (str "Can't translate from IB " ~table-name " " val#)
+			    {:value val#
+			     :table ~table-name
+			     :valid-values (vals to-table#)}))))))))
 
 (translation-table duration-unit
                    {:second "S"

--- a/src/ib_re_actor/translation.clj
+++ b/src/ib_re_actor/translation.clj
@@ -4,10 +4,31 @@
             [clj-time.coerce :as tc]
             [clojure.string :as str]))
 
-(defmulti ^:dynamic translate (fn [direction table-name _] [direction table-name]))
-(defmulti ^:dynamic valid? (fn [direction table-name _] [direction table-name]))
+(defmulti ^:dynamic translate
+  "Translate to or from a value from the Interactive Brokers API.
 
-(defmacro translation-table [name vals]
+Examples:
+user> (translate :to-ib :duration-unit :seconds)
+\"S\"
+user> (translate :from-ib :duration-unit \"S\")
+:second"
+  (fn [direction table-name _] [direction table-name]))
+
+(defmulti ^:dynamic valid?
+  "Check to see if a given value is an entry in the translation table.
+
+Examples:
+user> (valid? :to-ib :duration-unit :s)
+false
+user> (valid? :to-ib :duration-unit :seconds)
+true"
+  (fn [direction table-name _] [direction table-name]))
+
+(defmacro translation-table
+  "Creates a table for translating to and from string values from the Interactive
+Brokers API, as well as translate methods to and from the IB value and a method
+to check if if a given value is valid (known)."
+  [name vals]
   (let [table-name (keyword name)]
     `(let [to-table# ~vals
            from-table# (zipmap (vals to-table#) (keys to-table#))]

--- a/test/ib_re_actor/test/translation.clj
+++ b/test/ib_re_actor/test/translation.clj
@@ -3,6 +3,18 @@
         [clj-time.core :only [date-time]]
         [midje.sweet]))
 
+(fact "unknown string codes just translate into themselves"
+      (fact "coming from IB"
+	    (translate :from-ib :security-type "some weird value")
+	    => "some weird value")
+      (fact "going out to IB"
+	    (translate :to-ib :security-type "some weird value")
+	    => "some weird value"))
+
+(fact "unknown keyword codes throw"
+      (translate :to-ib :security-type :I-misspelled-something)
+      => (throws #"^Can't translate to IB"))
+
 (tabular
  (fact "it can translate to IB durations"
        (translate :to-ib :duration [?value ?unit]) => ?expected)


### PR DESCRIPTION
I often run into problems when a new, never-before-seen code comes up in something like `:order-type`. For example, this morning I requested contract details for "AAPL" :equity and one of the contracts had "ALGOTH" as one of the available order types. There is no entry for this order type in the code table for `:order-type`.

I don't know what that order type is and I don't care that much. It really shouldn't cause an error.

I think for some of the code tables, we should allow unknown values to just be translated into the literal value. So, for order type "ALGOTH" instead of trying to translate it into a symbol, just use the string value instead.

I think we can do this by modifying the translation table macro. I like the idea of having optional keywords before the map part, like the way the `defmappingtest` macro works in tests/../mapping.clj.
