### PR TITLE
Fix register-contract/lookup-contract

### DIFF
--- a/src/ib_re_actor/synchronous.clj
+++ b/src/ib_re_actor/synchronous.clj
@@ -59,8 +59,9 @@
   [con]
   (let [fields [:open-tick :bid-price :close-price :last-size :low
                 :ask-size :bid-size :last-price :ask-price :high :volume]
-        accept? (fn [{:keys [type contract]}]
-                  (and (= type :tick) (= contract con)))
+        my-ticker-id (g/get-ticker-id)
+        accept? (fn [{:keys [type contract ticker-id]}]
+                  (and (= type :tick) (= ticker-id my-ticker-id)))
         reduce-fn (fn [accum {:keys [field value]}]
                     (assoc accum field value))
         done? (fn [accum]
@@ -68,7 +69,7 @@
                   (every? received-fields fields)))
         complete (partial g/cancel-market-data con)]
     (reduce-responses accept? reduce-fn done? complete
-                      g/request-market-data con)))
+                      g/request-market-data my-ticker-id con)))
 
 (defn execute-order
   "Executes an order, returning only when the order is filled."

--- a/test/ib_re_actor/test/gateway.clj
+++ b/test/ib_re_actor/test/gateway.clj
@@ -10,7 +10,7 @@
 (testable-privates ib-re-actor.gateway dispatch-message create-wrapper)
 
 (def some-contract {:symbol "SOME TICKER"})
-(def some-contract-id (register-contract some-contract))
+(def some-ticker-id 999)
 
 (defn make-order-state []
   (let [ctor (first (.getDeclaredConstructors OrderState))]
@@ -53,40 +53,40 @@ wrapper, collecting and returning any messages the wrapper dispatched."
           :WAP 6.0})
 
 (fact "price ticks"
-      (wrapper->message (tickPrice some-contract-id 2 3.0 1))
+      (wrapper->message (tickPrice some-ticker-id 2 3.0 1))
       => {:type :tick :field :ask-price :value 3.0
-          :can-auto-execute? true :contract some-contract})
+          :can-auto-execute? true :ticker-id some-ticker-id})
 
 (fact "size ticks"
-      (wrapper->message (tickSize some-contract-id 3 4))
+      (wrapper->message (tickSize some-ticker-id 3 4))
       => {:type :tick :field :ask-size :value 4
-          :contract some-contract})
+          :ticker-id some-ticker-id})
 
 (fact "option computation ticks"
       (wrapper->message
-       (tickOptionComputation some-contract-id 10 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0))
-      => {:type :tick :field :bid-option-computation :contract some-contract
+       (tickOptionComputation some-ticker-id 10 2.0 3.0 4.0 5.0 6.0 7.0 8.0 9.0))
+      => {:type :tick :field :bid-option-computation :ticker-id some-ticker-id
           :implied-volatility 2.0 :delta 3.0 :option-price 4.0
           :pv-dividends 5.0 :gamma 6.0 :vega 7.0 :theta 8.0 :underlying-price 9.0})
 
 (fact "generic ticks"
-      (wrapper->message (tickGeneric some-contract-id 50 2.0))
+      (wrapper->message (tickGeneric some-ticker-id 50 2.0))
       => {:type :tick :field :bid-yield
-          :contract some-contract :value 2.0})
+          :ticker-id some-ticker-id :value 2.0})
 
 (fact "string ticks"
       (fact "last timestamp ticks"
             (wrapper->message
-             (tickString some-contract-id 45 "1000000000"))
+             (tickString some-ticker-id 45 "1000000000"))
             => {:type :tick :field :last-timestamp
-                :contract some-contract
+                :ticker-id some-ticker-id
                 :value (date-time 2001 9 9 1 46 40)}))
 
 (fact "EFP ticks"
-      (wrapper->message (tickEFP some-contract-id 38 2.0 "0.03 %" 4.0 5
+      (wrapper->message (tickEFP some-ticker-id 38 2.0 "0.03 %" 4.0 5
                                  "2001-04-01" 6.0 7.0))
       => {:type :tick :field :bid-efp-computation
-          :contract some-contract :basis-points 2.0
+          :ticker-id some-ticker-id :basis-points 2.0
           :formatted-basis-points "0.03 %"
           :implied-future 4.0 :hold-days 5 :future-expiry "2001-04-01"
           :dividend-impact 6.0 :dividends-to-expiry 7.0})
@@ -213,14 +213,14 @@ wrapper, collecting and returning any messages the wrapper dispatched."
       => {:type :execution-details-end :request-id 1})
 
 (fact "when market depth changes"
-      (wrapper->message (updateMktDepth some-contract-id 2 0 1 3.0 4))
-      => {:type :update-market-depth :contract some-contract :position 2
+      (wrapper->message (updateMktDepth some-ticker-id 2 0 1 3.0 4))
+      => {:type :update-market-depth :ticker-id some-ticker-id :position 2
           :operation :insert :side :bid :price 3.0 :size 4})
 
 (fact "when the Level II market depth changes"
-      (wrapper->message (updateMktDepthL2 some-contract-id 2 "some market maker"
+      (wrapper->message (updateMktDepthL2 some-ticker-id 2 "some market maker"
                                           1 0 3.0 4))
-      => {:type :update-market-depth-level-2 :contract some-contract :position 2
+      => {:type :update-market-depth-level-2 :ticker-id some-ticker-id :position 2
           :market-maker "some market maker" :operation :update :side :ask
           :price 3.0 :size 4})
 


### PR DESCRIPTION
These functions won't consider `{:symbol "AAPL" :exchange "ISLAND"}` and `{:symbol "AAPL" :exchange "ISLAND" :currency "USD"}` as the same security. If I request ticks for both, ib-re-actor will have two entries in `@id->contract` and make two requests. I am not sure if Interactive Brokers will send  the same ticks for both ticker ids (maybe it will ignore one of them?), but even if it did, this is kind of dumb.

Not sure if it would be better to go back to having the client track their own ticker-ids (that was how this used to work, and it was kind of a pain,) or forge onward and implement full-blown tracking of contract details.

The following is just kind of brain-stormy. If no one cares, I will probably try to do this sometime in the future.

I think "full-blown" tracking of contract details would involve:
- When we see a contract, like inside of `request-market-data`, we already call `register-contract` to see if we already have a ticker-id to use for this. Inside of `register-contract`, I think it should look for a match with a comparison function instead of using the contract as a key to lookup the ticker id. I think the comparison function could be pretty simple: if both have some subset of symbol, local-symbol, currency, exchange, contract-id, ..., then use those to compare and it's the same security if you have a match.
- When we see a new contract, kick off a request to get contract details for it. When we get a response, update our copy of the contract details.
- Since contract details have some time-specific data in them (trading/liquid hours, margin reqs., etc,) we need to refresh them from time to time. Maybe we could use the trading hours as some kind of a signal to refresh?

Writing this out has made me realize it's probably too much stuff for a library that is supposed to be a _wrapper_. On the other hand I hate to have to implement this every time I build an application that uses ib-re-actor. 

I have been considering starting a new project to build a host for trading algorithms. I have a couple of poorly designed applications I could replace if I did this, and it would be easier to maintain than several applications. The host could manage security reference data (as mentioned above) and keep that stuff out of the wrapper library. It would also include facilities to schedule things like activating trading programs at certain times and other market schedule driven processing.

Is anyone interested in pursuing a separate project (and revert to request-id based calls inside ib-re-actor) or should we fix the security reference data inside ib-re-actor? 
